### PR TITLE
Add indexer status warning bar

### DIFF
--- a/app/src/app/layout.tsx
+++ b/app/src/app/layout.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from 'next'
 import { Inter } from 'next/font/google'
 
 import { ClientProviders } from '@/components/providers/ClientProviders'
+import { IndexerWarning } from '@/components/IndexerWarning'
 import { BASE_URL } from '@/lib/constants'
 
 import './globals.css'
@@ -44,7 +45,10 @@ export default function RootLayout({
   return (
     <html lang="en" className="scroll-smooth">
       <body className={`${inter.variable} antialiased`}>
-        <ClientProviders>{children}</ClientProviders>
+        <ClientProviders>
+          <IndexerWarning />
+          {children}
+        </ClientProviders>
       </body>
     </html>
   )

--- a/app/src/components/IndexerWarning.tsx
+++ b/app/src/components/IndexerWarning.tsx
@@ -1,0 +1,15 @@
+import { useIndexerStatus } from '@/hooks/useIndexerStatus'
+
+export function IndexerWarning() {
+  const { isIndexerBehind } = useIndexerStatus()
+
+  if (!isIndexerBehind) return null
+
+  return (
+    <div className="bg-yellow-100 border-b border-yellow-200 p-2">
+      <p className="text-center text-sm text-yellow-800">
+        The data shown may be delayed as our indexer is currently catching up
+      </p>
+    </div>
+  )
+}

--- a/app/src/hooks/useIndexerStatus.ts
+++ b/app/src/hooks/useIndexerStatus.ts
@@ -1,0 +1,28 @@
+import { useEffect, useState } from 'react'
+
+export function useIndexerStatus() {
+  const [isIndexerBehind, setIsIndexerBehind] = useState(false)
+
+  useEffect(() => {
+    const checkIndexerStatus = async () => {
+      try {
+        const response = await fetch(
+          new URL('ready', process.env.NEXT_PUBLIC_PONDER_URL)
+        )
+        setIsIndexerBehind(!response.ok)
+      } catch (error) {
+        setIsIndexerBehind(true)
+      }
+    }
+
+    // Check immediately
+    checkIndexerStatus()
+
+    // Then check every 30 seconds
+    const interval = setInterval(checkIndexerStatus, 30000)
+
+    return () => clearInterval(interval)
+  }, [])
+
+  return { isIndexerBehind }
+}


### PR DESCRIPTION
This PR adds a warning bar that appears at the top of the page when the indexer is falling behind. It includes:

- New `useIndexerStatus` hook to check indexer status
- New `IndexerWarning` component to display the warning
- Integration into the root layout

The warning bar will automatically appear/disappear based on the indexer status, which is checked every 30 seconds.

Fixes #1