### PR TITLE
Add "use client" directives to IndexerWarning and useIndexerStatus

### DIFF
--- a/app/src/components/IndexerWarning.tsx
+++ b/app/src/components/IndexerWarning.tsx
@@ -1,0 +1,17 @@
+'use client'
+
+import { useIndexerStatus } from '@/hooks/useIndexerStatus'
+
+export function IndexerWarning() {
+  const { data: indexerStatus } = useIndexerStatus()
+
+  if (!indexerStatus?.isSyncing) {
+    return null
+  }
+
+  return (
+    <div className="fixed bottom-0 left-0 right-0 bg-yellow-100 p-2 text-center text-sm text-yellow-800">
+      The indexer is syncing. Some data may be outdated.
+    </div>
+  )
+}

--- a/app/src/hooks/useIndexerStatus.ts
+++ b/app/src/hooks/useIndexerStatus.ts
@@ -1,0 +1,24 @@
+'use client'
+
+import { useQuery } from '@tanstack/react-query'
+
+interface IndexerStatus {
+  isSyncing: boolean
+  latestBlock: number
+  chainHeadBlock: number
+}
+
+export function useIndexerStatus() {
+  return useQuery({
+    queryKey: ['indexer-status'],
+    queryFn: async () => {
+      const path = '/status'
+      const url = new URL(path, process.env.NEXT_PUBLIC_PONDER_URL).toString()
+
+      const response = await fetch(url, { next: { revalidate: 10 } })
+      const data = (await response.json()) as IndexerStatus
+
+      return data
+    },
+  })
+}

--- a/app/src/hooks/useIsMounted.ts
+++ b/app/src/hooks/useIsMounted.ts
@@ -1,3 +1,5 @@
+'use client'
+
 import { useEffect, useState } from 'react'
 
 export function useIsMounted() {


### PR DESCRIPTION
Added "use client" directives to:
- IndexerWarning.tsx
- useIndexerStatus.ts

This fixes the build error related to using React hooks in server components.