### PR TITLE
Estimate gas via app RPC instead of relying on wallet estimation

### DIFF
--- a/app/src/components/ProposalActionButton.tsx
+++ b/app/src/components/ProposalActionButton.tsx
@@ -2,16 +2,13 @@
 
 import { GovernorContract } from 'indexer/contracts'
 import { EnhancedProposal } from 'indexer/types'
-import { useState } from 'react'
 import {
   useAccount,
-  usePublicClient,
   useSimulateContract,
   useWaitForTransactionReceipt,
-  useWriteContract,
 } from 'wagmi'
 
-import { estimateGasParameters } from '@/lib/gas'
+import { useEstimatedWriteContract } from '@/hooks/useEstimatedWriteContract'
 import { cn } from '@/lib/utils'
 
 import { Button, buttonVariants } from './ui/button'
@@ -23,10 +20,8 @@ interface Props {
 
 export function ProposalActionButton({ proposal, action }: Props) {
   const { address } = useAccount()
-  const publicClient = usePublicClient()
-  const tx = useWriteContract()
+  const tx = useEstimatedWriteContract()
   const receipt = useWaitForTransactionReceipt({ hash: tx.data })
-  const [isEstimatingGas, setIsEstimatingGas] = useState(false)
 
   const data = {
     ...GovernorContract,
@@ -44,21 +39,9 @@ export function ProposalActionButton({ proposal, action }: Props) {
     query: { enabled: !!address },
   })
 
-  async function handleSubmit(e: React.FormEvent<HTMLFormElement>) {
+  function handleSubmit(e: React.FormEvent<HTMLFormElement>) {
     e.preventDefault()
-
-    setIsEstimatingGas(true)
-    try {
-      tx.writeContract({
-        ...data,
-        ...(await estimateGasParameters(publicClient, {
-          ...data,
-          account: address,
-        })),
-      })
-    } finally {
-      setIsEstimatingGas(false)
-    }
+    tx.writeContract(data)
   }
 
   if (!simulate.data) return null
@@ -84,7 +67,7 @@ export function ProposalActionButton({ proposal, action }: Props) {
         type="submit"
         variant="primary"
         className="w-full font-bold capitalize"
-        isLoading={isEstimatingGas || tx.isPending || receipt.isLoading}
+        isLoading={tx.isPending || receipt.isLoading}
       >
         {action}
       </Button>

--- a/app/src/components/ProposalActionButton.tsx
+++ b/app/src/components/ProposalActionButton.tsx
@@ -2,13 +2,16 @@
 
 import { GovernorContract } from 'indexer/contracts'
 import { EnhancedProposal } from 'indexer/types'
+import { useState } from 'react'
 import {
   useAccount,
+  usePublicClient,
   useSimulateContract,
   useWaitForTransactionReceipt,
   useWriteContract,
 } from 'wagmi'
 
+import { estimateGasParameters } from '@/lib/gas'
 import { cn } from '@/lib/utils'
 
 import { Button, buttonVariants } from './ui/button'
@@ -20,8 +23,10 @@ interface Props {
 
 export function ProposalActionButton({ proposal, action }: Props) {
   const { address } = useAccount()
+  const publicClient = usePublicClient()
   const tx = useWriteContract()
   const receipt = useWaitForTransactionReceipt({ hash: tx.data })
+  const [isEstimatingGas, setIsEstimatingGas] = useState(false)
 
   const data = {
     ...GovernorContract,
@@ -39,9 +44,21 @@ export function ProposalActionButton({ proposal, action }: Props) {
     query: { enabled: !!address },
   })
 
-  function handleSubmit(e: React.FormEvent<HTMLFormElement>) {
+  async function handleSubmit(e: React.FormEvent<HTMLFormElement>) {
     e.preventDefault()
-    tx.writeContract(data)
+
+    setIsEstimatingGas(true)
+    try {
+      tx.writeContract({
+        ...data,
+        ...(await estimateGasParameters(publicClient, {
+          ...data,
+          account: address,
+        })),
+      })
+    } finally {
+      setIsEstimatingGas(false)
+    }
   }
 
   if (!simulate.data) return null
@@ -67,7 +84,7 @@ export function ProposalActionButton({ proposal, action }: Props) {
         type="submit"
         variant="primary"
         className="w-full font-bold capitalize"
-        isLoading={tx.isPending || receipt.isLoading}
+        isLoading={isEstimatingGas || tx.isPending || receipt.isLoading}
       >
         {action}
       </Button>

--- a/app/src/components/VoteButton.tsx
+++ b/app/src/components/VoteButton.tsx
@@ -2,13 +2,11 @@
 
 import { GovernorContract } from 'indexer/contracts'
 import { EnhancedProposal } from 'indexer/types'
-import { useEffect, useState } from 'react'
+import { useEffect } from 'react'
 import {
   useAccount,
-  usePublicClient,
   useReadContracts,
   useWaitForTransactionReceipt,
-  useWriteContract,
 } from 'wagmi'
 
 import { Button } from '@/components/ui/button'
@@ -25,18 +23,16 @@ import {
 import { Label } from '@/components/ui/label'
 import { RadioGroup, RadioGroupItem } from '@/components/ui/radio-group'
 import { Textarea } from '@/components/ui/textarea'
+import { useEstimatedWriteContract } from '@/hooks/useEstimatedWriteContract'
 import { useIsMounted } from '@/hooks/useIsMounted'
 import revalidateProposal from '@/lib/actions'
-import { estimateGasParameters } from '@/lib/gas'
 import { bigintToFormattedString } from '@/lib/utils'
 
 export function VoteButton({ proposal }: { proposal: EnhancedProposal }) {
   const isMounted = useIsMounted()
   const { address } = useAccount()
-  const publicClient = usePublicClient()
-  const tx = useWriteContract()
+  const tx = useEstimatedWriteContract()
   const receipt = useWaitForTransactionReceipt({ hash: tx.data })
-  const [isEstimatingGas, setIsEstimatingGas] = useState(false)
 
   const multicall = useReadContracts({
     contracts: [
@@ -68,45 +64,24 @@ export function VoteButton({ proposal }: { proposal: EnhancedProposal }) {
     }
   }, [receipt.isSuccess])
 
-  async function handleSubmit(e: React.FormEvent<HTMLFormElement>) {
+  function handleSubmit(e: React.FormEvent<HTMLFormElement>) {
     e.preventDefault()
     const formData = new FormData(e.target as HTMLFormElement)
     const choice = Number(formData.get('choice') as string)
     const reason = formData.get('reason') as string
 
-    setIsEstimatingGas(true)
-    try {
-      if (reason) {
-        const request = {
-          ...GovernorContract,
-          functionName: 'castVoteWithReason',
-          args: [BigInt(proposal.id), choice, reason],
-        } as const
-
-        tx.writeContract({
-          ...request,
-          ...(await estimateGasParameters(publicClient, {
-            ...request,
-            account: address,
-          })),
-        })
-      } else {
-        const request = {
-          ...GovernorContract,
-          functionName: 'castVote',
-          args: [BigInt(proposal.id), choice],
-        } as const
-
-        tx.writeContract({
-          ...request,
-          ...(await estimateGasParameters(publicClient, {
-            ...request,
-            account: address,
-          })),
-        })
-      }
-    } finally {
-      setIsEstimatingGas(false)
+    if (reason) {
+      tx.writeContract({
+        ...GovernorContract,
+        functionName: 'castVoteWithReason',
+        args: [BigInt(proposal.id), choice, reason],
+      })
+    } else {
+      tx.writeContract({
+        ...GovernorContract,
+        functionName: 'castVote',
+        args: [BigInt(proposal.id), choice],
+      })
     }
   }
 
@@ -193,9 +168,7 @@ export function VoteButton({ proposal }: { proposal: EnhancedProposal }) {
                   type="submit"
                   variant="primary"
                   className="font-bold"
-                  isLoading={
-                    isEstimatingGas || tx.isPending || receipt.isLoading
-                  }
+                  isLoading={tx.isPending || receipt.isLoading}
                 >
                   Vote with {bigintToFormattedString(votingPower ?? '0')} $ENS
                 </Button>

--- a/app/src/components/VoteButton.tsx
+++ b/app/src/components/VoteButton.tsx
@@ -2,9 +2,10 @@
 
 import { GovernorContract } from 'indexer/contracts'
 import { EnhancedProposal } from 'indexer/types'
-import { useEffect } from 'react'
+import { useEffect, useState } from 'react'
 import {
   useAccount,
+  usePublicClient,
   useReadContracts,
   useWaitForTransactionReceipt,
   useWriteContract,
@@ -26,13 +27,16 @@ import { RadioGroup, RadioGroupItem } from '@/components/ui/radio-group'
 import { Textarea } from '@/components/ui/textarea'
 import { useIsMounted } from '@/hooks/useIsMounted'
 import revalidateProposal from '@/lib/actions'
+import { estimateGasParameters } from '@/lib/gas'
 import { bigintToFormattedString } from '@/lib/utils'
 
 export function VoteButton({ proposal }: { proposal: EnhancedProposal }) {
   const isMounted = useIsMounted()
   const { address } = useAccount()
+  const publicClient = usePublicClient()
   const tx = useWriteContract()
   const receipt = useWaitForTransactionReceipt({ hash: tx.data })
+  const [isEstimatingGas, setIsEstimatingGas] = useState(false)
 
   const multicall = useReadContracts({
     contracts: [
@@ -64,24 +68,45 @@ export function VoteButton({ proposal }: { proposal: EnhancedProposal }) {
     }
   }, [receipt.isSuccess])
 
-  function handleSubmit(e: React.FormEvent<HTMLFormElement>) {
+  async function handleSubmit(e: React.FormEvent<HTMLFormElement>) {
     e.preventDefault()
     const formData = new FormData(e.target as HTMLFormElement)
     const choice = Number(formData.get('choice') as string)
     const reason = formData.get('reason') as string
 
-    if (reason) {
-      tx.writeContract({
-        ...GovernorContract,
-        functionName: 'castVoteWithReason',
-        args: [BigInt(proposal.id), choice, reason],
-      })
-    } else {
-      tx.writeContract({
-        ...GovernorContract,
-        functionName: 'castVote',
-        args: [BigInt(proposal.id), choice],
-      })
+    setIsEstimatingGas(true)
+    try {
+      if (reason) {
+        const request = {
+          ...GovernorContract,
+          functionName: 'castVoteWithReason',
+          args: [BigInt(proposal.id), choice, reason],
+        } as const
+
+        tx.writeContract({
+          ...request,
+          ...(await estimateGasParameters(publicClient, {
+            ...request,
+            account: address,
+          })),
+        })
+      } else {
+        const request = {
+          ...GovernorContract,
+          functionName: 'castVote',
+          args: [BigInt(proposal.id), choice],
+        } as const
+
+        tx.writeContract({
+          ...request,
+          ...(await estimateGasParameters(publicClient, {
+            ...request,
+            account: address,
+          })),
+        })
+      }
+    } finally {
+      setIsEstimatingGas(false)
     }
   }
 
@@ -168,7 +193,9 @@ export function VoteButton({ proposal }: { proposal: EnhancedProposal }) {
                   type="submit"
                   variant="primary"
                   className="font-bold"
-                  isLoading={tx.isPending || receipt.isLoading}
+                  isLoading={
+                    isEstimatingGas || tx.isPending || receipt.isLoading
+                  }
                 >
                   Vote with {bigintToFormattedString(votingPower ?? '0')} $ENS
                 </Button>

--- a/app/src/hooks/useEstimatedWriteContract.ts
+++ b/app/src/hooks/useEstimatedWriteContract.ts
@@ -1,4 +1,19 @@
-import type { EstimateContractGasParameters, PublicClient } from 'viem'
+import { useMutation } from '@tanstack/react-query'
+import type {
+  Abi,
+  Address,
+  EstimateContractGasParameters,
+  PublicClient,
+} from 'viem'
+import { useAccount, usePublicClient, useWriteContract } from 'wagmi'
+
+type EstimatedWriteContractParameters = {
+  abi: Abi
+  address: Address
+  functionName: string
+  args?: readonly unknown[]
+  value?: bigint
+}
 
 // Wallets like MetaMask often overestimate gas, which makes transactions look
 // (and sometimes be) more expensive than necessary. Estimating through our own
@@ -10,16 +25,10 @@ import type { EstimateContractGasParameters, PublicClient } from 'viem'
 // refunded, so this doesn't increase the actual cost.
 const GAS_LIMIT_BUFFER_PERCENT = BigInt(20)
 
-export type GasParameters = {
-  gas?: bigint
-  maxFeePerGas?: bigint
-  maxPriorityFeePerGas?: bigint
-}
-
-export async function estimateGasParameters(
+async function estimateGasParameters(
   client: PublicClient | undefined,
   params: EstimateContractGasParameters
-): Promise<GasParameters> {
+) {
   if (!client) return {}
 
   try {
@@ -38,4 +47,25 @@ export async function estimateGasParameters(
     console.error('Gas estimation failed:', error)
     return {}
   }
+}
+
+// Drop-in alternative to `useWriteContract` that estimates gas before writing.
+// `isPending` covers both the estimation and the wallet confirmation.
+export function useEstimatedWriteContract() {
+  const { address } = useAccount()
+  const publicClient = usePublicClient()
+  const { writeContractAsync } = useWriteContract()
+
+  const mutation = useMutation({
+    mutationFn: async (params: EstimatedWriteContractParameters) => {
+      const gasParams = await estimateGasParameters(publicClient, {
+        ...params,
+        account: address,
+      })
+
+      return writeContractAsync({ ...params, ...gasParams })
+    },
+  })
+
+  return { ...mutation, writeContract: mutation.mutate }
 }

--- a/app/src/lib/gas.ts
+++ b/app/src/lib/gas.ts
@@ -1,0 +1,41 @@
+import type { EstimateContractGasParameters, PublicClient } from 'viem'
+
+// Wallets like MetaMask often overestimate gas, which makes transactions look
+// (and sometimes be) more expensive than necessary. Estimating through our own
+// RPC and attaching the results to the transaction makes wallets use them as
+// the suggested values instead of estimating themselves.
+
+// Headroom over the node's gas estimate so transactions don't run out of gas
+// if state changes slightly between estimation and execution. Unused gas is
+// refunded, so this doesn't increase the actual cost.
+const GAS_LIMIT_BUFFER_PERCENT = BigInt(20)
+
+export type GasParameters = {
+  gas?: bigint
+  maxFeePerGas?: bigint
+  maxPriorityFeePerGas?: bigint
+}
+
+export async function estimateGasParameters(
+  client: PublicClient | undefined,
+  params: EstimateContractGasParameters
+): Promise<GasParameters> {
+  if (!client) return {}
+
+  try {
+    const [gas, fees] = await Promise.all([
+      client.estimateContractGas(params),
+      client.estimateFeesPerGas(),
+    ])
+
+    return {
+      gas: (gas * (BigInt(100) + GAS_LIMIT_BUFFER_PERCENT)) / BigInt(100),
+      maxFeePerGas: fees.maxFeePerGas,
+      maxPriorityFeePerGas: fees.maxPriorityFeePerGas,
+    }
+  } catch (error) {
+    // Fall back to the wallet's own estimation instead of blocking the tx
+    console.error('Gas estimation failed:', error)
+    return {}
+  }
+}


### PR DESCRIPTION
Wallets like MetaMask often overestimate both the gas limit and fee
rates, making transactions unnecessarily expensive. Estimate the gas
limit (with a 20% buffer) and EIP-1559 fees through the app's own RPC
and attach them to writeContract calls, so wallets use them as the
suggested values. Falls back to wallet estimation if the RPC call
fails.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_017p5TzK4krS3P6pB93KvCoA