### PR TITLE
Group standalone proposal code into blocks

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -37,6 +37,7 @@
   },
   "devDependencies": {
     "@trivago/prettier-plugin-sort-imports": "^5.2.0",
+    "@types/mdast": "^4.0.4",
     "@types/node": "^20",
     "@types/react": "^19",
     "@types/react-dom": "^19",

--- a/app/src/app/proposal/[id]/client.tsx
+++ b/app/src/app/proposal/[id]/client.tsx
@@ -29,6 +29,7 @@ import {
 } from '@/components/ui/table'
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs'
 import { Typography } from '@/components/ui/typography'
+import { remarkGroupCodeOnlyParagraphs } from '@/lib/remarkGroupCodeOnlyParagraphs'
 import {
   formatTimestamp,
   getQuorumProgress,
@@ -183,25 +184,11 @@ export function ProposalPageClient({ proposal }: Props) {
                     h6: ({ children }) => (
                       <Typography as="h6">{children}</Typography>
                     ),
-                    p: ({ children, node }) => {
-                      const isCodeOnlyParagraph =
-                        node?.children.length === 1 &&
-                        node.children[0].type === 'element' &&
-                        node.children[0].tagName === 'code'
-
-                      return (
-                        <Typography
-                          as="p"
-                          className={
-                            isCodeOnlyParagraph
-                              ? 'my-6 max-w-full overflow-x-auto rounded-md bg-muted p-4 font-mono'
-                              : 'break-words'
-                          }
-                        >
-                          {children}
-                        </Typography>
-                      )
-                    },
+                    p: ({ children }) => (
+                      <Typography as="p" className="break-words">
+                        {children}
+                      </Typography>
+                    ),
                     a: ({ children, href }) => (
                       <a
                         href={href}
@@ -255,7 +242,7 @@ export function ProposalPageClient({ proposal }: Props) {
                       </pre>
                     ),
                   }}
-                  remarkPlugins={[remarkGfm]}
+                  remarkPlugins={[remarkGfm, remarkGroupCodeOnlyParagraphs]}
                 >
                   {proposal.description}
                 </ReactMarkdown>

--- a/app/src/app/proposal/[id]/client.tsx
+++ b/app/src/app/proposal/[id]/client.tsx
@@ -183,11 +183,25 @@ export function ProposalPageClient({ proposal }: Props) {
                     h6: ({ children }) => (
                       <Typography as="h6">{children}</Typography>
                     ),
-                    p: ({ children }) => (
-                      <Typography as="p" className="break-words">
-                        {children}
-                      </Typography>
-                    ),
+                    p: ({ children, node }) => {
+                      const isCodeOnlyParagraph =
+                        node?.children.length === 1 &&
+                        node.children[0].type === 'element' &&
+                        node.children[0].tagName === 'code'
+
+                      return (
+                        <Typography
+                          as="p"
+                          className={
+                            isCodeOnlyParagraph
+                              ? 'my-6 max-w-full overflow-x-auto rounded-md bg-muted p-4 font-mono'
+                              : 'break-words'
+                          }
+                        >
+                          {children}
+                        </Typography>
+                      )
+                    },
                     a: ({ children, href }) => (
                       <a
                         href={href}

--- a/app/src/lib/remarkGroupCodeOnlyParagraphs.ts
+++ b/app/src/lib/remarkGroupCodeOnlyParagraphs.ts
@@ -1,0 +1,44 @@
+import type { InlineCode, Paragraph, Root, RootContent } from 'mdast'
+
+type CodeOnlyParagraph = Paragraph & { children: [InlineCode] }
+
+function isCodeOnlyParagraph(node: RootContent): node is CodeOnlyParagraph {
+  return (
+    node.type === 'paragraph' &&
+    node.children.length === 1 &&
+    node.children[0].type === 'inlineCode'
+  )
+}
+
+export function remarkGroupCodeOnlyParagraphs() {
+  return (tree: Root) => {
+    const groupedChildren: RootContent[] = []
+
+    for (let index = 0; index < tree.children.length; index += 1) {
+      const child = tree.children[index]
+
+      if (!isCodeOnlyParagraph(child)) {
+        groupedChildren.push(child)
+        continue
+      }
+
+      const values = [child.children[0].value]
+
+      while (index + 1 < tree.children.length) {
+        const nextChild = tree.children[index + 1]
+
+        if (!isCodeOnlyParagraph(nextChild)) break
+
+        index += 1
+        values.push(nextChild.children[0].value)
+      }
+
+      groupedChildren.push({
+        type: 'code',
+        value: values.join('\n\n'),
+      })
+    }
+
+    tree.children = groupedChildren
+  }
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -115,6 +115,9 @@ importers:
       '@trivago/prettier-plugin-sort-imports':
         specifier: ^5.2.0
         version: 5.2.2(prettier@3.5.3)
+      '@types/mdast':
+        specifier: ^4.0.4
+        version: 4.0.4
       '@types/node':
         specifier: ^20
         version: 20.17.30


### PR DESCRIPTION
## Summary

- verify that the affected proposal stores `To`, `Value`, and `Calldata` as adjacent paragraphs containing inline-code nodes, rather than fenced code blocks
- add a small remark plugin that groups each adjacent run of code-only paragraphs into one real Markdown code block, preserving blank lines between fields
- keep code embedded in prose as a compact inline highlight
- retain the existing padded, muted styling for actual code blocks

## Validation

- `pnpm --filter app exec prettier --check 'src/app/proposal/[id]/client.tsx' 'src/lib/remarkGroupCodeOnlyParagraphs.ts' package.json`
- `pnpm --filter app exec tsc --noEmit`
- rendered representative source Markdown and verified that three adjacent fields produce one `<pre><code>` block while inline code remains inside its paragraph